### PR TITLE
update PusherSwift SDK to 8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- Update PusherSwift library from 7.2.0 to 8.0.0
+
 ## 1.0.2
 
 - Fixes Android build error with missing trigger method. By @athornz

--- a/ios/Classes/SwiftPusherPlugin.swift
+++ b/ios/Classes/SwiftPusherPlugin.swift
@@ -66,7 +66,7 @@ public class SwiftPusherPlugin: NSObject, FlutterPlugin, PusherDelegate {
                 authMethod: initArgs.options.auth != nil ? AuthMethod.authRequestBuilder(authRequestBuilder: AuthRequestBuilder(endpoint: initArgs.options.auth!.endpoint, headers: initArgs.options.auth!.headers)): .noMethod,
                 host: initArgs.options.host != nil ? .host(initArgs.options.host!) : (initArgs.options.cluster != nil ? .cluster(initArgs.options.cluster!) : .host("ws.pusherapp.com")),
                 port: initArgs.options.port ?? (initArgs.options.encrypted ?? true ? 443 : 80),
-                encrypted: initArgs.options.encrypted ?? true,
+                useTLS: initArgs.options.encrypted ?? true,
                 activityTimeout: Double(initArgs.options.activityTimeout ?? 30000) / 1000
             )
             

--- a/ios/Classes/UserAgent.h
+++ b/ios/Classes/UserAgent.h
@@ -1,4 +1,4 @@
 // Generated file, do not edit
-#define LIBRARY_VERSION @"1.0.1"
+#define LIBRARY_VERSION @"1.0.3"
 #define LIBRARY_NAME @"flutter_pusher"
-#define PUSHER_LIBRARY_VERSION @"7.2.0"
+#define PUSHER_LIBRARY_VERSION @"8.0.0"

--- a/ios/flutter_pusher.podspec
+++ b/ios/flutter_pusher.podspec
@@ -4,7 +4,7 @@
 require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 libraryVersion = pubspec['version'].gsub('+', '-')
-pusherLibraryVersion = '7.2.0'
+pusherLibraryVersion = '8.0.0'
 
 Pod::Spec.new do |s|
   s.name             = 'flutter_pusher'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_pusher
 description: A Flutter plugin to listen to events sent through pusher. Wraps the native Java and Swift libraries.
-version: 1.0.2
+version: 1.0.3
 author: Indoor Solutions <ninjas@indoor.solutions>
 homepage: https://github.com/ninjasolutions/flutter_pusher
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Xcode 12.5 can't compile a component of CryptoSwift. This PR updates the SDK to remove the CryptoSwift dependency.

It does not update to the latest SDK (9.2.2) because that update enforces the minimum deployment target of iOS 13. There should be an intermediate version (this PR) before forcing the upgrade to 13.

### :arrow_heading_down: What is the current behavior?

Can't build in Xcode 12.5

### :new: What is the new behavior (if this is a feature change)?

### :boom: Does this PR introduce a breaking change?

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/ninjasolutions/flutter_pusher/blob/master/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
