### PR TITLE
fix flutter android deprecation warning

### DIFF
--- a/android/src/main/java/com/ninjasolutions/pusher/PusherPlugin.java
+++ b/android/src/main/java/com/ninjasolutions/pusher/PusherPlugin.java
@@ -1,5 +1,7 @@
 package com.ninjasolutions.pusher;
 
+import androidx.annotation.NonNull;
+
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
@@ -31,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -43,7 +46,7 @@ import static com.ninjasolutions.pusher.PusherPlugin.TAG;
 /**
  * PusherPlugin
  */
-public class PusherPlugin implements MethodCallHandler {
+public class PusherPlugin implements FlutterPlugin, MethodCallHandler {
     private static Pusher pusher;
     private static Map<String, Channel> channels = new HashMap<>();
     private static EventChannelListener eventListener;
@@ -60,12 +63,23 @@ public class PusherPlugin implements MethodCallHandler {
     public static void registerWith(Registrar registrar) {
         final MethodChannel channel = new MethodChannel(registrar.messenger(), "plugins.indoor.solutions/pusher");
         final EventChannel eventStream = new EventChannel(registrar.messenger(), "plugins.indoor.solutions/pusherStream");
+        channel.setMethodCallHandler(new PusherPlugin());
+        PusherPlugin.migratedPluginRegistration(channel, eventStream);
+    }
 
+    @Override
+    public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
+        final MethodChannel channel = new MethodChannel(flutterPluginBinding.getBinaryMessenger(), "plugins.indoor.solutions/pusher");
+        final EventChannel eventStream = new EventChannel(flutterPluginBinding.getBinaryMessenger(), "plugins.indoor.solutions/pusherStream");
+        channel.setMethodCallHandler(this);
+        PusherPlugin.migratedPluginRegistration(channel, eventStream);
+    }
+
+    public static void migratedPluginRegistration(MethodChannel channel, EventChannel eventStream) {
         eventListener = new EventChannelListener();
         eventListenerPrivate = new PrivateChannelChannelListener();
         eventListenerPresence = new PresenceChannelChannelListener();
 
-        channel.setMethodCallHandler(new PusherPlugin());
         eventStream.setStreamHandler(new EventChannel.StreamHandler() {
             @Override
             public void onListen(Object args, final EventChannel.EventSink eventSink) {
@@ -396,6 +410,11 @@ public class PusherPlugin implements MethodCallHandler {
                 e.printStackTrace();
             }
         }
+    }
+
+    @Override
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+        // TODO implement
     }
 }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Flutter has a new Android plugin interface

### :arrow_heading_down: What is the current behavior?

There's a warning on `flutter pub get`

### :new: What is the new behavior (if this is a feature change)?

There is no warning on `flutter pub get`

### :boom: Does this PR introduce a breaking change?

No

### :bug: Recommendations for testing

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines ([code style guide](https://github.com/ninjasolutions/flutter_pusher/blob/master/CONTRIBUTING.md))
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
